### PR TITLE
fix: update API endpoint for cluster status query

### DIFF
--- a/src/pages/cluster/hooks.ts
+++ b/src/pages/cluster/hooks.ts
@@ -14,7 +14,7 @@ import {
 export const useClusterStatus = () => {
   return useQuery({
     queryKey: ["status"],
-    queryFn: () => api.get<GetStatusResult>("/v1/status"),
+    queryFn: () => api.get<GetStatusResult>("/v2/GetClusterStatus"),
   });
 };
 


### PR DESCRIPTION
fix: update API endpoint for cluster status query in garage v2.0.0(from /v1/status to /v2/GetClusterStatus