### PR TITLE
fix: active storage node status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ dist-ssr
 .env*
 !.env.example
 docker-compose.*.yml
+
+data/
+meta/
+garage.toml

--- a/src/pages/home/page.tsx
+++ b/src/pages/home/page.tsx
@@ -38,8 +38,8 @@ const HomePage = () => {
             health?.status === "healthy"
               ? "text-success"
               : health?.status === "degraded"
-              ? "text-warning"
-              : "text-error"
+                ? "text-warning"
+                : "text-error"
           )}
         />
         <StatsCard title="Nodes" icon={HardDrive} value={health?.knownNodes} />
@@ -56,7 +56,7 @@ const HomePage = () => {
         <StatsCard
           title="Active Storage Nodes"
           icon={DatabaseZap}
-          value={health?.storageNodesOk}
+          value={health?.storageNodesUp}
         />
         <StatsCard
           title="Partitions"

--- a/src/pages/home/types.ts
+++ b/src/pages/home/types.ts
@@ -5,7 +5,7 @@ export type GetHealthResult = {
   knownNodes: number;
   connectedNodes: number;
   storageNodes: number;
-  storageNodesOk: number;
+  storageNodesUp: number;
   partitions: number;
   partitionsQuorum: number;
   partitionsAllOk: number;


### PR DESCRIPTION
Fixes the Active Storage Nodes status on the Dashboard not showing active nodes.
This was due to v2.1.0 of Garage, renaming `storage_nodes_ok ` to `storage_nodes_up` 

https://git.deuxfleurs.fr/Deuxfleurs/garage/releases/tag/v2.1.0

> A single breaking change was included in the admin API, due to a constraint of the Go SDK generator:
> `storage_nodes_ok` is renamed to `storage_nodes_up` in GetClusterHealthResponse, to fix generated SDK code ([#1111](https://git.deuxfleurs.fr/Deuxfleurs/garage/issues/1111))