### PR TITLE
Update README for escaping dollar signs

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,10 @@ webui:
   environment:
     AUTH_USER_PASS: "username:$2y$10$DSTi9o..."
 ```
+Docker Compose treats $ as the start of an environment variable.
+Since bcrypt hashes can contain $ characters, Compose will try to substitute them and may emit warnings or truncate the value.
+To pass a literal $, you must escape it as $$
+
 
 ### Running
 

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ webui:
 ```
 Docker Compose treats $ as the start of an environment variable.
 Since bcrypt hashes can contain $ characters, Compose will try to substitute them and may emit warnings or truncate the value.
-To pass a literal $, you must escape it as $$
+To pass a literal ''$'', you must escape it as ''$$''
 
 
 ### Running


### PR DESCRIPTION

Clarify escaping of dollar signs in Docker Compose.